### PR TITLE
fix: call delete instead of free

### DIFF
--- a/source/pareto/common/hypervolume.h
+++ b/source/pareto/common/hypervolume.h
@@ -817,7 +817,7 @@ namespace pareto {
 
         /* Clean up. */
         free_cdllist(list);
-        free(tree); /* The nodes are freed by free_cdllist ().  */
+        delete tree; /* The nodes are freed by free_cdllist ().  */
 
         return hyperv;
     }


### PR DESCRIPTION
Call `delete` instead of `free` for memory that was allocated
using `new`.